### PR TITLE
replace qsort_r by kissat version of sorting

### DIFF
--- a/catch.c
+++ b/catch.c
@@ -16,7 +16,6 @@
 // to be deleted (from the checker or in general have been 'lost').
 
 /*------------------------------------------------------------------------*/
-#define _GNU_SOURCE
 #include "catch.h"
 #include "colors.h"
 #include "stack.h"

--- a/main.c
+++ b/main.c
@@ -10,7 +10,6 @@
 // make a mess out of our nicely formatted 'usage' message.  After the
 // definition there is another comment switching formatting on again.
 
-#define _GNU_SOURCE
 // *INDENT-OFF*
 
 static const char *usage =

--- a/satch.h
+++ b/satch.h
@@ -5,8 +5,6 @@
 // All functions are implemented in 'satch.c' except for the last three
 // returning build information. Those are implemented in 'config.c'.
 
-#define _GNU_SOURCE
-
 // The parser and witness printer implemented in the stand-alone solver
 // front-end 'main.c' are not considered to be part of the library.
 


### PR DESCRIPTION
Use the sorting version by kissat instead of using qsort_r which is not in POSIX and has a different argument order on BSD.